### PR TITLE
Fix Assert isDirectory in addSourceFolder()

### DIFF
--- a/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSystemWatcher.java
+++ b/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/FileSystemWatcher.java
@@ -114,7 +114,7 @@ public class FileSystemWatcher {
 	 */
 	public synchronized void addSourceFolder(File folder) {
 		Assert.notNull(folder, "Folder must not be null");
-		Assert.isFalse(folder.isDirectory(), "Folder must not be a file");
+		Assert.isTrue(!folder.isDirectory(), "Folder must not be a file");
 		checkNotStarted();
 		this.folders.put(folder, null);
 	}


### PR DESCRIPTION
Fixed Assert to check if folder is not a directory:
Original Implementation checked the opposite (assert if it was a directory) which is not the wanted behavior
